### PR TITLE
Update container image versions

### DIFF
--- a/apply_updates.py
+++ b/apply_updates.py
@@ -1,0 +1,223 @@
+import json
+import sys
+from ruamel.yaml import YAML
+from ruamel.yaml.scalarstring import LiteralScalarString, DoubleQuotedScalarString
+from packaging.version import parse as parse_version, InvalidVersion
+
+def eprint(*args, **kwargs):
+    """Helper function to print to stderr."""
+    print(*args, file=sys.stderr, **kwargs)
+
+def parse_image_string(image_str):
+    if not isinstance(image_str, str):
+        return None, None
+    
+    name = image_str
+    tag = None # Default if no tag is specified or if it's part of a digest
+
+    if '@' in image_str: # Handle digests, image_name@sha256:digest
+        name_part, digest_part = image_str.split('@', 1)
+        # For this function, we are interested in name and potential tag before digest
+        name = name_part 
+
+    if ':' in name:
+        parts = name.rsplit(':', 1)
+        # Check if the part after ':' could be a tag
+        # For apply_updates, we need to be more careful than in scanning.
+        # Rely on currentVersion matching.
+        name = parts[0]
+        tag = parts[1]
+            
+    return name, tag
+
+def update_yaml_data(data, target_image_name, current_version, new_version, file_path):
+    """
+    Recursively searches and updates image versions in YAML data.
+    Returns True if an update was made, False otherwise.
+    """
+    if isinstance(data, dict):
+        # Pattern 1: Direct image string: image: "name:tag" or image: "name" (implies latest or a digest)
+        if 'image' in data and isinstance(data['image'], str):
+            img_full_str = data['image']
+            img_name_in_yaml, img_tag_in_yaml = parse_image_string(img_full_str)
+
+            # Normalize target_image_name if it has library/ prefix from crane
+            normalized_target_image_name = target_image_name
+            if target_image_name.startswith("library/") and not img_name_in_yaml.startswith("library/"):
+                 normalized_target_image_name = target_image_name.split("library/",1)[1]
+
+
+            if img_name_in_yaml == normalized_target_image_name and str(img_tag_in_yaml) == str(current_version):
+                new_image_str = f"{img_name_in_yaml}:{new_version}"
+                # Preserve quote style if possible
+                if isinstance(data['image'], DoubleQuotedScalarString):
+                    data['image'] = DoubleQuotedScalarString(new_image_str)
+                elif isinstance(data['image'], LiteralScalarString): # Less common for image strings
+                    data['image'] = LiteralScalarString(new_image_str)
+                else:
+                    data['image'] = new_image_str
+                eprint(f"  Updated direct image in {file_path}: {img_full_str} -> {new_image_str}")
+                return True
+            # Handle cases where current_version might be 'latest' implicitly if tag is missing
+            elif img_name_in_yaml == normalized_target_image_name and img_tag_in_yaml is None and str(current_version).lower() == 'latest':
+                new_image_str = f"{img_name_in_yaml}:{new_version}"
+                if isinstance(data['image'], DoubleQuotedScalarString): data['image'] = DoubleQuotedScalarString(new_image_str)
+                else: data['image'] = new_image_str
+                eprint(f"  Updated direct image (implicit latest) in {file_path}: {img_full_str} -> {new_image_str}")
+                return True
+
+
+        # Pattern 2: Image object: image: { repository: "name", tag: "tag" }
+        if 'image' in data and isinstance(data['image'], dict):
+            img_obj = data['image']
+            repo = img_obj.get('repository')
+            tag = img_obj.get('tag')
+            
+            # Normalize target_image_name for repo comparison
+            normalized_target_image_name_for_repo = target_image_name
+            if target_image_name.startswith("library/") and repo and not repo.startswith("library/"):
+                 normalized_target_image_name_for_repo = target_image_name.split("library/",1)[1]
+            
+            # Check if registry is part of repo or separate
+            registry = img_obj.get('registry')
+            full_repo_name_in_yaml = f"{registry}/{repo}" if registry and repo else repo
+
+            if (repo == target_image_name or full_repo_name_in_yaml == target_image_name or \
+                repo == normalized_target_image_name_for_repo or full_repo_name_in_yaml == normalized_target_image_name_for_repo) \
+                and str(tag) == str(current_version):
+                
+                # Preserve quote style for tag
+                if isinstance(img_obj['tag'], DoubleQuotedScalarString):
+                    img_obj['tag'] = DoubleQuotedScalarString(str(new_version))
+                elif isinstance(img_obj['tag'], LiteralScalarString): # Should not happen for tags typically
+                     img_obj['tag'] = LiteralScalarString(str(new_version))
+                else:
+                    img_obj['tag'] = str(new_version) # Cast new_version to string as tags can be numbers
+                eprint(f"  Updated image object tag in {file_path}: {repo}:{tag} -> {new_version}")
+                return True
+        
+        # Pattern 3: Kustomize 'images' block
+        if 'images' in data and isinstance(data['images'], list) and \
+           data.get('kind') == 'Kustomization': # Check kind for safety
+            for img_override in data['images']:
+                if isinstance(img_override, dict):
+                    kustomize_name = img_override.get('name')      # Original name referred in kustomize
+                    kustomize_newName = img_override.get('newName') # Can be full image OR just name part
+                    kustomize_newTag = img_override.get('newTag')
+
+                    # Case 1: Update newTag if newName matches target_image_name (without tag) and newTag matches current_version
+                    if kustomize_newName and kustomize_newTag and \
+                       kustomize_newName == target_image_name and str(kustomize_newTag) == str(current_version):
+                        img_override['newTag'] = str(new_version)
+                        eprint(f"  Updated Kustomize newTag for {kustomize_newName} in {file_path}: {kustomize_newTag} -> {new_version}")
+                        return True
+                    
+                    # Case 2: Update newTag if name matches target_image_name and newTag matches current_version (newName might be absent)
+                    if not kustomize_newName and kustomize_name and kustomize_newTag and \
+                       kustomize_name == target_image_name and str(kustomize_newTag) == str(current_version):
+                        img_override['newTag'] = str(new_version)
+                        eprint(f"  Updated Kustomize newTag for {kustomize_name} in {file_path}: {kustomize_newTag} -> {new_version}")
+                        return True
+
+                    # Case 3: newName contains the full image name and current_version as its tag
+                    if kustomize_newName and not kustomize_newTag: # Tag is part of newName
+                        parsed_newName_name, parsed_newName_tag = parse_image_string(kustomize_newName)
+                        if parsed_newName_name == target_image_name and str(parsed_newName_tag) == str(current_version):
+                            img_override['newName'] = f"{parsed_newName_name}:{new_version}"
+                            eprint(f"  Updated Kustomize newName in {file_path}: {kustomize_newName} -> {img_override['newName']}")
+                            return True
+            # If an image is only defined by `name:` and its original chart tag,
+            # and we want to update it, we'd add `newTag` or `newName`.
+            # This script focuses on updating existing version strings.
+
+        # Recurse
+        for key, value in data.items():
+            if update_yaml_data(value, target_image_name, current_version, new_version, file_path):
+                return True
+
+    elif isinstance(data, list):
+        for item in data:
+            if update_yaml_data(item, target_image_name, current_version, new_version, file_path):
+                return True
+                
+    return False
+
+def main():
+    try:
+        with open("image_updates_proposed.json", 'r') as f:
+            proposed_updates = json.load(f)
+    except FileNotFoundError:
+        eprint("Error: image_updates_proposed.json not found.")
+        return
+    except json.JSONDecodeError:
+        eprint("Error: Could not decode image_updates_proposed.json.")
+        return
+
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    # yaml.indent(mapping=2, sequence=4, offset=2) # Optional: control indentation
+
+    successful_changes = []
+    error_logs = []
+
+    for update_entry in proposed_updates:
+        if not update_entry.get("updateNeeded", False):
+            continue
+
+        file_path = update_entry["filePath"]
+        image_name = update_entry["imageName"] # Name from registry/previous scan
+        current_version = str(update_entry["currentVersion"])
+        new_version = str(update_entry["newVersion"])
+
+        eprint(f"\nAttempting update for: {image_name}:{current_version} -> {new_version} in {file_path}")
+
+        if new_version.startswith("Error:"):
+            eprint(f"  Skipping due to error in newVersion: {new_version}")
+            error_logs.append(f"Skipped {file_path} for {image_name} due to error in newVersion: {new_version}")
+            continue
+        
+        try:
+            with open(file_path, 'r') as f:
+                # Use list to load all documents if multi-doc YAML
+                yaml_docs = list(yaml.load_all(f))
+            
+            made_change_in_file = False
+            for doc_idx, doc_data in enumerate(yaml_docs):
+                if update_yaml_data(doc_data, image_name, current_version, new_version, file_path):
+                    made_change_in_file = True
+                    # No need to break here, one image might be in multiple docs (though unlikely for version updates)
+                    # or multiple distinct images could be in one file but handled by outer loop over proposed_updates.
+                    # This loop is for multi-document YAML files.
+            
+            if made_change_in_file:
+                with open(file_path, 'w') as f:
+                    yaml.dump_all(yaml_docs, f)
+                log_message = f"Successfully updated {image_name} from {current_version} to {new_version} in {file_path}"
+                eprint(f"  {log_message}")
+                successful_changes.append(log_message)
+            else:
+                err_msg = f"Image {image_name}:{current_version} not found or not updated in {file_path} as expected."
+                eprint(f"  Warning: {err_msg}")
+                error_logs.append(err_msg)
+
+        except FileNotFoundError:
+            err_msg = f"File {file_path} not found for update."
+            eprint(f"  Error: {err_msg}")
+            error_logs.append(err_msg)
+        except Exception as e:
+            err_msg = f"Error processing file {file_path}: {e}"
+            eprint(f"  Error: {err_msg}")
+            error_logs.append(err_msg)
+
+    eprint("\n--- Summary ---")
+    eprint("Successful changes:")
+    for log in successful_changes:
+        eprint(f"- {log}")
+    
+    if error_logs:
+        eprint("\nErrors and Warnings:")
+        for log in error_logs:
+            eprint(f"- {log}")
+
+if __name__ == "__main__":
+    main()

--- a/apps/3d/bambu/values.yaml
+++ b/apps/3d/bambu/values.yaml
@@ -5,7 +5,7 @@ controllers:
       app:
         image:
           repository: lscr.io/linuxserver/bambustudio
-          tag: 02.00.02
+          tag: 2.0.3
           pullPolicy: IfNotPresent
         env:
           TZ: "America/Chicago"
@@ -27,17 +27,17 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt-cloudflare
       external-dns.alpha.kubernetes.io/internal-hostname: bambu.sievert.fun
     hosts:
-      - host: bambu.sievert.fun
-        paths:
-          - path: /
-            pathType: Prefix
-            service:
-              identifier: app
-              port: http
+    - host: bambu.sievert.fun
+      paths:
+      - path: /
+        pathType: Prefix
+        service:
+          identifier: app
+          port: http
     tls:
-      - secretName: bambu-tls
-        hosts:
-          - bambu.sievert.fun
+    - secretName: bambu-tls
+      hosts:
+      - bambu.sievert.fun
 
 podSecurityContext:
   runAsUser: 1000
@@ -53,4 +53,4 @@ persistence:
     storageClass: khal-drogo-nfs
     size: 1Gi
     globalMounts:
-      - path: /config
+    - path: /config

--- a/apps/3d/manyfold/values.yaml
+++ b/apps/3d/manyfold/values.yaml
@@ -55,7 +55,7 @@ controllers:
       app:
         image:
           repository: redis
-          tag: "7.2"
+          tag: "7.4.3"
           pullPolicy: IfNotPresent
         env:
           REDIS_PASSWORD:
@@ -70,7 +70,7 @@ controllers:
       app:
         image:
           repository: postgres
-          tag: "16.2"
+          tag: "16.9"
           pullPolicy: IfNotPresent
         env:
           POSTGRES_USER:
@@ -115,17 +115,17 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt-cloudflare
       external-dns.alpha.kubernetes.io/internal-hostname: manyfold.sievert.fun
     hosts:
-      - host: manyfold.sievert.fun
-        paths:
-          - path: /
-            pathType: Prefix
-            service:
-              identifier: app
-              port: http
+    - host: manyfold.sievert.fun
+      paths:
+      - path: /
+        pathType: Prefix
+        service:
+          identifier: app
+          port: http
     tls:
-      - secretName: manyfold-tls
-        hosts:
-          - manyfold.sievert.fun
+    - secretName: manyfold-tls
+      hosts:
+      - manyfold.sievert.fun
 
 podSecurityContext:
   runAsUser: 1000
@@ -141,7 +141,7 @@ persistence:
     storageClass: khal-drogo-nfs
     size: 1Gi
     globalMounts:
-      - path: /config
+    - path: /config
 
   redis:
     enabled: true

--- a/apps/media/audiobooks/values.yaml
+++ b/apps/media/audiobooks/values.yaml
@@ -5,7 +5,7 @@ controllers:
       app:
         image:
           repository: ghcr.io/advplyr/audiobookshelf
-          tag: 2.20.0
+          tag: 2.23.0
           pullPolicy: IfNotPresent
         env:
           TZ: "America/Chicago"
@@ -28,17 +28,17 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt-cloudflare
       external-dns.alpha.kubernetes.io/internal-hostname: audiobooks.sievert.fun
     hosts:
-      - host: audiobooks.sievert.fun
-        paths:
-          - path: /
-            pathType: Prefix
-            service:
-              identifier: app
-              port: http
+    - host: audiobooks.sievert.fun
+      paths:
+      - path: /
+        pathType: Prefix
+        service:
+          identifier: app
+          port: http
     tls:
-      - secretName: audiobooks-tls
-        hosts:
-          - audiobooks.sievert.fun
+    - secretName: audiobooks-tls
+      hosts:
+      - audiobooks.sievert.fun
 
 podSecurityContext:
   runAsUser: 1001
@@ -54,7 +54,7 @@ persistence:
     storageClass: local-path
     size: 1Gi
     globalMounts:
-      - path: /config
+    - path: /config
   media:
     enabled: true
     type: persistentVolumeClaim

--- a/apps/media/lidarr/values.yaml
+++ b/apps/media/lidarr/values.yaml
@@ -5,7 +5,7 @@ controllers:
       app:
         image:
           repository: ghcr.io/home-operations/lidarr
-          tag: 2.10.1.4589
+          tag: 2.12.0.4633
           pullPolicy: IfNotPresent
         env:
           TZ: "America/Chicago"
@@ -24,17 +24,17 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt-cloudflare
       external-dns.alpha.kubernetes.io/internal-hostname: lidarr.sievert.fun
     hosts:
-      - host: lidarr.sievert.fun
-        paths:
-          - path: /
-            pathType: Prefix
-            service:
-              identifier: app
-              port: http
+    - host: lidarr.sievert.fun
+      paths:
+      - path: /
+        pathType: Prefix
+        service:
+          identifier: app
+          port: http
     tls:
-      - secretName: lidarr-tls
-        hosts:
-          - lidarr.sievert.fun
+    - secretName: lidarr-tls
+      hosts:
+      - lidarr.sievert.fun
 
 podSecurityContext:
   runAsUser: 65534
@@ -50,7 +50,7 @@ persistence:
     storageClass: local-path
     size: 1Gi
     globalMounts:
-      - path: /config
+    - path: /config
   media:
     enabled: true
     type: persistentVolumeClaim

--- a/apps/media/prowlarr/values.yaml
+++ b/apps/media/prowlarr/values.yaml
@@ -5,7 +5,7 @@ controllers:
       app:
         image:
           repository: ghcr.io/home-operations/prowlarr
-          tag: 1.32.2.4987
+          tag: 1.36.2.5059
           pullPolicy: IfNotPresent
         env:
           TZ: "America/Chicago"
@@ -29,17 +29,17 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt-cloudflare
       external-dns.alpha.kubernetes.io/internal-hostname: prowlarr.sievert.fun
     hosts:
-      - host: prowlarr.sievert.fun
-        paths:
-          - path: /
-            pathType: Prefix
-            service:
-              identifier: app
-              port: http
+    - host: prowlarr.sievert.fun
+      paths:
+      - path: /
+        pathType: Prefix
+        service:
+          identifier: app
+          port: http
     tls:
-      - secretName: prowlarr-tls
-        hosts:
-          - prowlarr.sievert.fun
+    - secretName: prowlarr-tls
+      hosts:
+      - prowlarr.sievert.fun
 
 podSecurityContext:
   runAsUser: 65534
@@ -55,4 +55,4 @@ persistence:
     storageClass: local-path
     size: 1Gi
     globalMounts:
-      - path: /config
+    - path: /config

--- a/apps/media/radarr/values.yaml
+++ b/apps/media/radarr/values.yaml
@@ -5,7 +5,7 @@ controllers:
       app:
         image:
           repository: ghcr.io/home-operations/radarr
-          tag: 5.20.2.9777
+          tag: 5.23.3.9987
           pullPolicy: IfNotPresent
         env:
           TZ: "America/Chicago"
@@ -24,17 +24,17 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt-cloudflare
       external-dns.alpha.kubernetes.io/internal-hostname: radarr.sievert.fun
     hosts:
-      - host: radarr.sievert.fun
-        paths:
-          - path: /
-            pathType: Prefix
-            service:
-              identifier: app
-              port: http
+    - host: radarr.sievert.fun
+      paths:
+      - path: /
+        pathType: Prefix
+        service:
+          identifier: app
+          port: http
     tls:
-      - secretName: radarr-tls
-        hosts:
-          - radarr.sievert.fun
+    - secretName: radarr-tls
+      hosts:
+      - radarr.sievert.fun
 
 podSecurityContext:
   runAsUser: 65534
@@ -50,7 +50,7 @@ persistence:
     storageClass: local-path
     size: 1Gi
     globalMounts:
-      - path: /config
+    - path: /config
   media:
     enabled: true
     type: persistentVolumeClaim

--- a/apps/media/readarr/values.yaml
+++ b/apps/media/readarr/values.yaml
@@ -5,7 +5,7 @@ controllers:
       app:
         image:
           repository: ghcr.io/home-operations/readarr
-          tag: 0.4.12.2753
+          tag: 0.4.16.2793
           pullPolicy: IfNotPresent
         env:
           TZ: "America/Chicago"
@@ -24,17 +24,17 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt-cloudflare
       external-dns.alpha.kubernetes.io/internal-hostname: readarr.sievert.fun
     hosts:
-      - host: readarr.sievert.fun
-        paths:
-          - path: /
-            pathType: Prefix
-            service:
-              identifier: app
-              port: http
+    - host: readarr.sievert.fun
+      paths:
+      - path: /
+        pathType: Prefix
+        service:
+          identifier: app
+          port: http
     tls:
-      - secretName: readarr-tls
-        hosts:
-          - readarr.sievert.fun
+    - secretName: readarr-tls
+      hosts:
+      - readarr.sievert.fun
 
 podSecurityContext:
   runAsUser: 65534
@@ -50,7 +50,7 @@ persistence:
     storageClass: local-path
     size: 1Gi
     globalMounts:
-      - path: /config
+    - path: /config
   media:
     enabled: true
     type: persistentVolumeClaim

--- a/apps/media/sabnzbd/values.yaml
+++ b/apps/media/sabnzbd/values.yaml
@@ -5,7 +5,7 @@ controllers:
       app:
         image:
           repository: ghcr.io/home-operations/sabnzbd
-          tag: 4.4.1
+          tag: 4.5.1
           pullPolicy: IfNotPresent
         env:
           TZ: "America/Chicago"
@@ -32,17 +32,17 @@ ingress:
       cert-manager.io/cluster-issuer: letsencrypt-cloudflare
       external-dns.alpha.kubernetes.io/internal-hostname: sabnzbd.sievert.fun
     hosts:
-      - host: sabnzbd.sievert.fun
-        paths:
-          - path: /
-            pathType: Prefix
-            service:
-              identifier: app
-              port: http
+    - host: sabnzbd.sievert.fun
+      paths:
+      - path: /
+        pathType: Prefix
+        service:
+          identifier: app
+          port: http
     tls:
-      - secretName: sabnzbd-tls
-        hosts:
-          - sabnzbd.sievert.fun
+    - secretName: sabnzbd-tls
+      hosts:
+      - sabnzbd.sievert.fun
 
 podSecurityContext:
   runAsUser: 65534
@@ -58,7 +58,7 @@ persistence:
     storageClass: local-path
     size: 1Gi
     globalMounts:
-      - path: /config
+    - path: /config
   media:
     enabled: true
     type: persistentVolumeClaim

--- a/image_references.json
+++ b/image_references.json
@@ -1,0 +1,77 @@
+[
+  {
+    "file_path": "apps/3d/bambu/values.yaml",
+    "image_name": "lscr.io/linuxserver/bambustudio",
+    "image_tag": "02.00.02"
+  },
+  {
+    "file_path": "apps/3d/manyfold/values.yaml",
+    "image_name": "lscr.io/linuxserver/manyfoldstudio",
+    "image_tag": "02.00.02"
+  },
+  {
+    "file_path": "apps/3d/manyfold/values.yaml",
+    "image_name": "postgres",
+    "image_tag": "16.2"
+  },
+  {
+    "file_path": "apps/3d/manyfold/values.yaml",
+    "image_name": "redis",
+    "image_tag": "7.2"
+  },
+  {
+    "file_path": "apps/infrastructure/vault/values.yaml",
+    "image_name": "vault",
+    "image_tag": "1.16.1"
+  },
+  {
+    "file_path": "apps/media/audiobooks/values.yaml",
+    "image_name": "ghcr.io/advplyr/audiobookshelf",
+    "image_tag": "2.20.0"
+  },
+  {
+    "file_path": "apps/media/lidarr/values.yaml",
+    "image_name": "ghcr.io/home-operations/lidarr",
+    "image_tag": "2.10.1.4589"
+  },
+  {
+    "file_path": "apps/media/notifiarr/values.yaml",
+    "image_name": "golift/notifiarr",
+    "image_tag": "0.8.3"
+  },
+  {
+    "file_path": "apps/media/profilarr/values.yaml",
+    "image_name": "santiagosayshey/profilarr",
+    "image_tag": "v1.0.1"
+  },
+  {
+    "file_path": "apps/media/prowlarr/values.yaml",
+    "image_name": "ghcr.io/home-operations/prowlarr",
+    "image_tag": "1.32.2.4987"
+  },
+  {
+    "file_path": "apps/media/radarr/values.yaml",
+    "image_name": "ghcr.io/home-operations/radarr",
+    "image_tag": "5.20.2.9777"
+  },
+  {
+    "file_path": "apps/media/readarr/values.yaml",
+    "image_name": "ghcr.io/home-operations/readarr",
+    "image_tag": "0.4.12.2753"
+  },
+  {
+    "file_path": "apps/media/sabnzbd/values.yaml",
+    "image_name": "ghcr.io/home-operations/sabnzbd",
+    "image_tag": "4.4.1"
+  },
+  {
+    "file_path": "apps/media/sonarr/values.yaml",
+    "image_name": "ghcr.io/home-operations/sonarr",
+    "image_tag": "4.0.14.2938"
+  },
+  {
+    "file_path": "apps/tools/it-tools/values.yaml",
+    "image_name": "corentinth/it-tools",
+    "image_tag": "2024.10.22-7ca5933"
+  }
+]

--- a/image_scanner.py
+++ b/image_scanner.py
@@ -1,0 +1,151 @@
+import yaml
+import json
+import glob
+import sys
+
+def parse_image_string(image_str, file_path_for_debug=""):
+    if not isinstance(image_str, str):
+        eprint(f"DEBUG: Non-string image value found in {file_path_for_debug}: {image_str}")
+        return None, None
+    
+    name = image_str
+    tag = 'latest' # Default if no tag is specified
+
+    if '@' in image_str: # Handle digests, remove them for name part
+        name_part, digest_part = image_str.split('@', 1)
+        name = name_part # Keep the original name before @ for further parsing
+
+    if ':' in name:
+        parts = name.rsplit(':', 1)
+        # Check if the part after ':' is a valid tag (not a port number like :8080)
+        # A simple heuristic: if it contains a letter or typical version chars like '.', '-', it's likely a tag.
+        # If it's all digits, it could be a port. This is not foolproof.
+        # For this script, we'll assume if ':' is present, the last part is the tag.
+        if len(parts) == 2:
+            name = parts[0]
+            tag = parts[1]
+            
+    # eprint(f"DEBUG: Parsed image string '{image_str}' to name='{name}', tag='{tag}' in {file_path_for_debug}")
+    return name, tag
+
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+def find_images_recursive(data, file_path, images_found, path_trace=""):
+    if isinstance(data, dict):
+        # Pattern: image: { repository: "repo", tag: "tag" }
+        if 'image' in data and isinstance(data['image'], dict):
+            img_obj = data['image']
+            repo = img_obj.get('repository')
+            tag = img_obj.get('tag')
+            if repo and tag is not None:
+                registry = img_obj.get('registry')
+                name = f"{registry}/{repo}" if registry and repo else repo
+                images_found.add((file_path, name, str(tag)))
+                eprint(f"DEBUG: {file_path} -> Added (Pat: image_dict): {name}:{str(tag)} from path {path_trace}.image")
+
+        # Pattern: image: "repository:tag"
+        elif 'image' in data and isinstance(data['image'], str):
+            name, tag = parse_image_string(data['image'], file_path)
+            if name:
+                images_found.add((file_path, name, str(tag)))
+                eprint(f"DEBUG: {file_path} -> Added (Pat: image_str): {name}:{str(tag)} from path {path_trace}.image")
+
+        # Pattern: 'repository' and 'tag' keys at the same level
+        elif 'repository' in data and 'tag' in data and isinstance(data['repository'], str) and data.get('tag') is not None:
+            if not ('image' in data and isinstance(data['image'], dict)): # Avoid double count if part of image: {}
+                 repo = data['repository']
+                 tag_val = data['tag']
+                 registry = data.get('registry')
+                 name = f"{registry}/{repo}" if registry and repo else repo
+                 images_found.add((file_path, name, str(tag_val)))
+                 eprint(f"DEBUG: {file_path} -> Added (Pat: repo_tag_direct): {name}:{str(tag_val)} from path {path_trace}")
+        
+        # Pattern: Kustomize 'images' block
+        # apiVersion: kustomize.config.k8s.io/v1beta1, kind: Kustomization
+        if 'images' in data and isinstance(data['images'], list) and \
+           'apiVersion' in data and 'kustomize.config.k8s.io' in data['apiVersion'] and \
+           'kind' in data and data['kind'] == 'Kustomization':
+            eprint(f"DEBUG: {file_path} -> Found Kustomize 'images' block at path {path_trace}.images")
+            for i, img_override in enumerate(data['images']):
+                if isinstance(img_override, dict):
+                    orig_name = img_override.get('name') # Original name, for context
+                    new_name_val = img_override.get('newName')
+                    new_tag_val = img_override.get('newTag')
+
+                    if new_name_val: # newName is mandatory for an effective override for this entry
+                        final_name, final_tag = parse_image_string(new_name_val, file_path)
+                        if new_tag_val: # if newTag is also specified, it overrides any tag in newName
+                            final_tag = str(new_tag_val)
+                        
+                        if final_name: # final_name must be valid
+                            images_found.add((file_path, final_name, final_tag))
+                            eprint(f"DEBUG: {file_path} -> Added (Pat: kustomize_images): {final_name}:{final_tag} from {path_trace}.images[{i}] (orig: {orig_name})")
+                    elif orig_name and new_tag_val: # Case: only tag is changed for an image
+                        # This means we are only changing the tag of 'orig_name'.
+                        # 'orig_name' itself isn't a deployed image if the chart uses different defaults.
+                        # For this script, we only care about fully specified deployable images.
+                        # If a kustomization only provides a newTag, it assumes the original image name is resolved elsewhere.
+                        # We will record this as orig_name:new_tag_val as this is the effective image spec from this file.
+                        images_found.add((file_path, orig_name, str(new_tag_val)))
+                        eprint(f"DEBUG: {file_path} -> Added (Pat: kustomize_images_tag_only): {orig_name}:{str(new_tag_val)} from {path_trace}.images[{i}]")
+
+
+        # Kubernetes container specs (simplified)
+        for container_key_type in ['containers', 'initContainers']:
+            if container_key_type in data and isinstance(data[container_key_type], list):
+                for i, container in enumerate(data[container_key_type]):
+                    if isinstance(container, dict) and 'image' in container and isinstance(container['image'], str):
+                        name, tag = parse_image_string(container['image'], file_path)
+                        if name:
+                            images_found.add((file_path, name, str(tag)))
+                            eprint(f"DEBUG: {file_path} -> Added (Pat: k8s_container_direct): {name}:{str(tag)} from path {path_trace}.{container_key_type}[{i}]")
+        
+        # General recursion
+        for key, value in data.items():
+            if key == 'image' and (isinstance(value, str) or ('repository' in value and 'tag' in value if isinstance(value, dict) else False)):
+                continue
+            if key == 'images' and 'apiVersion' in data and 'kustomize.config.k8s.io' in data['apiVersion']: # Avoid re-processing kustomize images list
+                continue
+
+            new_trace = f"{path_trace}.{key}" if path_trace else key
+            find_images_recursive(value, file_path, images_found, new_trace)
+
+    elif isinstance(data, list):
+        for i, item in enumerate(data):
+            new_trace = f"{path_trace}[{i}]"
+            find_images_recursive(item, file_path, images_found, new_trace)
+
+def main():
+    base_path = 'apps/'
+    yaml_files = glob.glob(f"{base_path}**/*.yaml", recursive=True)
+    yml_files = glob.glob(f"{base_path}**/*.yml", recursive=True)
+    filepaths = yaml_files + yml_files
+    
+    eprint(f"DEBUG: Found {len(filepaths)} YAML files to scan.")
+
+    all_images_set = set()
+
+    for fp in filepaths:
+        eprint(f"DEBUG: Scanning file: {fp}")
+        try:
+            with open(fp, 'r', encoding='utf-8') as f:
+                for doc_index, doc in enumerate(yaml.safe_load_all(f)):
+                    if doc:
+                        eprint(f"DEBUG: Processing document #{doc_index} in {fp}")
+                        find_images_recursive(doc, fp, all_images_set, f"doc[{doc_index}]")
+                    else:
+                        eprint(f"DEBUG: Skipping empty document #{doc_index} in {fp}")
+        except yaml.YAMLError as e:
+            eprint(f"WARN: YAML parsing error in {fp}: {e}")
+        except Exception as e:
+            eprint(f"WARN: Unexpected error processing file {fp}: {e}")
+
+    output_list = [
+        {'file_path': item[0], 'image_name': item[1], 'image_tag': str(item[2])}
+        for item in sorted(list(all_images_set))
+    ]
+    print(json.dumps(output_list, indent=2))
+
+if __name__ == "__main__":
+    main()

--- a/image_updates_proposed.json
+++ b/image_updates_proposed.json
@@ -1,0 +1,122 @@
+[
+  {
+    "filePath": "apps/3d/bambu/values.yaml",
+    "imageName": "lscr.io/linuxserver/bambustudio",
+    "currentVersion": "02.00.02",
+    "newVersion": "2.0.3",
+    "updateNeeded": true,
+    "reason": "Rule pattern '['^lscr.io/linuxserver/manyfoldstudio$', '^lscr.io/linuxserver/bambustudio$']' matched. Allowed versions: '02.00.x' (parsed as '<2.1.0,>=2.0.0'). Latest satisfying version is 2.0.3."
+  },
+  {
+    "filePath": "apps/3d/manyfold/values.yaml",
+    "imageName": "lscr.io/linuxserver/manyfoldstudio",
+    "currentVersion": "02.00.02",
+    "newVersion": "Error: Could not fetch tags",
+    "updateNeeded": false,
+    "reason": "Failed to fetch tags for lscr.io/linuxserver/manyfoldstudio."
+  },
+  {
+    "filePath": "apps/3d/manyfold/values.yaml",
+    "imageName": "postgres",
+    "currentVersion": "16.2",
+    "newVersion": "16.9",
+    "updateNeeded": true,
+    "reason": "Rule pattern '['^postgres$']' matched. Allowed versions: '16.x' (parsed as '<17.0.0,>=16.0.0'). Latest satisfying version is 16.9."
+  },
+  {
+    "filePath": "apps/3d/manyfold/values.yaml",
+    "imageName": "redis",
+    "currentVersion": "7.2",
+    "newVersion": "7.4.3",
+    "updateNeeded": true,
+    "reason": "Rule pattern '['^redis$']' matched. Allowed versions: '7.x' (parsed as '<8.0.0,>=7.0.0'). Latest satisfying version is 7.4.3."
+  },
+  {
+    "filePath": "apps/infrastructure/vault/values.yaml",
+    "imageName": "vault",
+    "currentVersion": "1.16.1",
+    "newVersion": "1.16.1",
+    "updateNeeded": false,
+    "reason": "Already at or above the latest satisfying version (1.13.3)."
+  },
+  {
+    "filePath": "apps/media/audiobooks/values.yaml",
+    "imageName": "ghcr.io/advplyr/audiobookshelf",
+    "currentVersion": "2.20.0",
+    "newVersion": "2.23.0",
+    "updateNeeded": true,
+    "reason": "Rule pattern '['^ghcr.io/advplyr/audiobookshelf$']' matched. Allowed versions: '2.x' (parsed as '<3.0.0,>=2.0.0'). Latest satisfying version is 2.23.0."
+  },
+  {
+    "filePath": "apps/media/lidarr/values.yaml",
+    "imageName": "ghcr.io/home-operations/lidarr",
+    "currentVersion": "2.10.1.4589",
+    "newVersion": "2.12.0.4633",
+    "updateNeeded": true,
+    "reason": "Latest satisfying version is 2.12.0.4633."
+  },
+  {
+    "filePath": "apps/media/notifiarr/values.yaml",
+    "imageName": "golift/notifiarr",
+    "currentVersion": "0.8.3",
+    "newVersion": "0.8.3",
+    "updateNeeded": false,
+    "reason": "Already at or above the latest satisfying version (0.8.3)."
+  },
+  {
+    "filePath": "apps/media/profilarr/values.yaml",
+    "imageName": "santiagosayshey/profilarr",
+    "currentVersion": "v1.0.1",
+    "newVersion": "v1.0.1",
+    "updateNeeded": false,
+    "reason": "Already at or above the latest satisfying version (1.0.1)."
+  },
+  {
+    "filePath": "apps/media/prowlarr/values.yaml",
+    "imageName": "ghcr.io/home-operations/prowlarr",
+    "currentVersion": "1.32.2.4987",
+    "newVersion": "1.36.2.5059",
+    "updateNeeded": true,
+    "reason": "Latest satisfying version is 1.36.2.5059."
+  },
+  {
+    "filePath": "apps/media/radarr/values.yaml",
+    "imageName": "ghcr.io/home-operations/radarr",
+    "currentVersion": "5.20.2.9777",
+    "newVersion": "5.23.3.9987",
+    "updateNeeded": true,
+    "reason": "Latest satisfying version is 5.23.3.9987."
+  },
+  {
+    "filePath": "apps/media/readarr/values.yaml",
+    "imageName": "ghcr.io/home-operations/readarr",
+    "currentVersion": "0.4.12.2753",
+    "newVersion": "0.4.16.2793",
+    "updateNeeded": true,
+    "reason": "Latest satisfying version is 0.4.16.2793."
+  },
+  {
+    "filePath": "apps/media/sabnzbd/values.yaml",
+    "imageName": "ghcr.io/home-operations/sabnzbd",
+    "currentVersion": "4.4.1",
+    "newVersion": "4.5.1",
+    "updateNeeded": true,
+    "reason": "Latest satisfying version is 4.5.1."
+  },
+  {
+    "filePath": "apps/media/sonarr/values.yaml",
+    "imageName": "ghcr.io/home-operations/sonarr",
+    "currentVersion": "4.0.14.2938",
+    "newVersion": "4.0.14.2938",
+    "updateNeeded": false,
+    "reason": "Already at or above the latest satisfying version (4.0.14.2938)."
+  },
+  {
+    "filePath": "apps/tools/it-tools/values.yaml",
+    "imageName": "corentinth/it-tools",
+    "currentVersion": "2024.10.22-7ca5933",
+    "newVersion": "2024.10.22-7ca5933",
+    "updateNeeded": false,
+    "reason": "No suitable version found in registry matching constraints."
+  }
+]

--- a/version_checker.py
+++ b/version_checker.py
@@ -1,0 +1,330 @@
+import json
+import json5 # For parsing renovate.json5
+import re
+import subprocess
+from packaging.version import parse as parse_version, InvalidVersion
+from packaging.specifiers import SpecifierSet, InvalidSpecifier
+import os
+import sys
+
+# Set PATH to include .local/bin for crane if it was installed there by pip for the user
+os.environ["PATH"] = os.path.expanduser("~/.local/bin") + os.pathsep + os.environ["PATH"]
+CRANE_CMD = '/usr/local/bin/crane'
+
+
+def eprint(*args, **kwargs):
+    """Helper function to print to stderr."""
+    print(*args, file=sys.stderr, **kwargs)
+
+
+def get_tags_from_registry(image_name):
+    eprint(f"Fetching tags for {image_name} using {CRANE_CMD}...")
+    try:
+        # Using stdout=PIPE and iterating lines
+        process = subprocess.Popen([CRANE_CMD, 'ls', image_name], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        stdout, stderr = process.communicate(timeout=60) # process.stdout is now a string
+
+        if process.returncode != 0:
+            eprint(f"Error fetching tags for {image_name} with {CRANE_CMD} (return code {process.returncode}): {stderr}")
+            # Try Docker Hub default if applicable
+            if '/' not in image_name:
+                eprint(f"Retrying {image_name} as library/{image_name} for Docker Hub default...")
+                process_retry = subprocess.Popen([CRANE_CMD, 'ls', f"library/{image_name}"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+                stdout_retry, stderr_retry = process_retry.communicate(timeout=60)
+                if process_retry.returncode == 0:
+                    tags_retry = stdout_retry.strip().splitlines() # Use splitlines()
+                    eprint(f"Found tags for library/{image_name} ({len(tags_retry)} total). First 15: {tags_retry[:15]}...")
+                    return tags_retry, f"library/{image_name}"
+                else:
+                    eprint(f"Error fetching tags for library/{image_name} with {CRANE_CMD}: {stderr_retry}")
+                    return None, f"library/{image_name}"
+            return None, image_name # Original name if error and not Docker Hub default case
+
+        tags = stdout.strip().splitlines() # Use splitlines()
+        
+        eprint(f"Found tags for {image_name} ({len(tags)} total). First 15: {tags[:15]}...")
+        if image_name == "vault":
+             eprint(f"  DEBUG FOR VAULT: Raw tag count: {len(tags)}")
+             eprint(f"  DEBUG FOR VAULT: Last 15 tags from crane: {tags[-15:]}...")
+             if "1.17.0" not in tags: eprint("  DEBUG FOR VAULT: Tag '1.17.0' NOT in raw tags list from crane!")
+             if "1.16.3" not in tags: eprint("  DEBUG FOR VAULT: Tag '1.16.3' NOT in raw tags list from crane!")
+             if "1.16.1" not in tags: eprint("  DEBUG FOR VAULT: Tag '1.16.1' NOT in raw tags list from crane!")
+        return tags, image_name
+
+    except subprocess.TimeoutExpired:
+        eprint(f"Timeout fetching tags for {image_name}")
+        if process and process.poll() is None: process.kill() # Ensure process is killed
+        return None, image_name
+    except FileNotFoundError:
+        eprint(f"CRANE COMMAND '{CRANE_CMD}' NOT FOUND.")
+        raise
+    except Exception as e: # Catch any other unexpected errors during subprocess handling
+        eprint(f"An unexpected error occurred with subprocess for {image_name}: {e}")
+        return None, image_name
+
+
+def parse_allowed_versions(allowed_str):
+    if not allowed_str:
+        return None
+    match = re.fullmatch(r"(\d+)\.x", allowed_str)
+    if match:
+        major = int(match.group(1))
+        return SpecifierSet(f">={major}.0.0,<{major + 1}.0.0")
+    match = re.fullmatch(r"(\d+)\.(\d+)\.x", allowed_str)
+    if match:
+        major = int(match.group(1))
+        minor = int(match.group(2))
+        return SpecifierSet(f">={major}.{minor}.0,<{major}.{minor + 1}.0")
+    try:
+        return SpecifierSet(allowed_str)
+    except InvalidSpecifier:
+        eprint(f"Warning: Could not parse allowedVersions string '{allowed_str}' into a valid specifier.")
+        return None
+
+def get_latest_matching_version(tags, image_name_for_debug, specifier_set=None, current_version_str=""):
+    if not tags:
+        return None
+
+    candidate_versions = []
+    current_semver = None
+    if current_version_str:
+        try:
+            parsed_tag = current_version_str[1:] if current_version_str.startswith('v') else current_version_str
+            current_semver = parse_version(parsed_tag)
+        except InvalidVersion:
+             eprint(f"  Note: Current version '{current_version_str}' for {image_name_for_debug} is not standard semver.")
+
+    for tag_idx, tag in enumerate(tags): 
+        tag_to_parse = tag
+        
+        if image_name_for_debug == "vault" and tag in ["1.17.0", "1.16.3", "1.16.1", "1.13.3"]:
+            eprint(f"  VAULT_TAG_TRACE: Encountered tag '{tag}' at index {tag_idx}.")
+
+        if tag.lower() in ['latest', 'main', 'master', 'dev', 'stable', 'edge', 'rolling', 'nightly', 
+                           'alpha', 'beta', 'rc', 'test', 'testing', 'snapshot', 'canary']:
+            if image_name_for_debug == "vault" and tag in ["1.17.0", "1.16.3", "1.16.1", "1.13.3"]: 
+                 eprint(f"  VAULT_TAG_TRACE: Tag '{tag}' was skipped by common name filter.")
+            continue
+        
+        if tag.startswith('v'):
+            tag_to_parse = tag[1:]
+        
+        try:
+            version = parse_version(tag_to_parse)
+            candidate_versions.append(version)
+            if image_name_for_debug == "vault" and tag in ["1.17.0", "1.16.3", "1.16.1", "1.13.3"]:
+                 eprint(f"  VAULT_TAG_TRACE: Tag '{tag}' parsed as {version} and added to candidates.")
+        except InvalidVersion:
+            if image_name_for_debug == "vault" and tag in ["1.17.0", "1.16.3", "1.16.1", "1.13.3"]:
+                 eprint(f"  VAULT_TAG_TRACE: Tag '{tag}' failed to parse.")
+            continue 
+
+    if image_name_for_debug == "vault":
+        eprint(f"  DEBUG FOR VAULT: All parsed candidate_versions ({len(candidate_versions)}): Sample: {sorted([v for v in candidate_versions if str(v).startswith('1.17') or str(v).startswith('1.16') or str(v).startswith('1.13')], reverse=True)[:30]}...")
+
+
+    if not candidate_versions:
+        eprint(f"  No parseable semantic versions found in tags for {image_name_for_debug}.")
+        return None
+
+    if specifier_set:
+        filtered_versions = [v for v in candidate_versions if specifier_set.contains(v)]
+        eprint(f"  For spec '{specifier_set}' on {image_name_for_debug}, filtered versions (sample): {sorted(filtered_versions, reverse=True)[:5]}")
+    else:
+        if current_semver and current_semver.is_prerelease:
+            filtered_versions = [
+                v for v in candidate_versions 
+                if not v.is_prerelease or (v.is_prerelease and v.base_version >= current_semver.base_version)
+            ]
+        elif not current_semver and current_version_str: 
+             filtered_versions = candidate_versions 
+        else: 
+            filtered_versions = [v for v in candidate_versions if not v.is_prerelease]
+            if not filtered_versions and candidate_versions: 
+                eprint(f"  No stable versions found for {image_name_for_debug}. Considering pre-releases as fallback.")
+                is_any_stable = any(not v.is_prerelease for v in candidate_versions)
+                if not is_any_stable:
+                    filtered_versions = candidate_versions
+    
+    if image_name_for_debug == "vault":
+        eprint(f"  DEBUG FOR VAULT: Final filtered_versions before max ({len(filtered_versions)}): Sample: {sorted([v for v in filtered_versions if str(v).startswith('1.17') or str(v).startswith('1.16') or str(v).startswith('1.13')], reverse=True)[:30]}...")
+        if filtered_versions:
+            eprint(f"  DEBUG FOR VAULT: Type of elements in filtered_versions: {type(filtered_versions[0])}")
+            test_v117 = parse_version("1.17.0")
+            is_117_present = test_v117 in filtered_versions
+            eprint(f"  DEBUG FOR VAULT: Is Version('1.17.0') in filtered_versions? {is_117_present}")
+            if not is_117_present: 
+                for cv in candidate_versions:
+                    if cv.base_version == "1.17.0" and not cv.is_prerelease and not cv.is_devrelease and cv.local is None :
+                        eprint(f"  DEBUG FOR VAULT: Found 1.17.0 equivalent in candidates: {cv} (is_prerelease={cv.is_prerelease})")
+                        if cv not in filtered_versions:
+                            eprint(f"  DEBUG FOR VAULT: But it was not in filtered_versions. Filtered_versions len: {len(filtered_versions)}")
+                        break
+
+
+    if not filtered_versions:
+        eprint(f"  No versions matched filters for {image_name_for_debug} (spec: {specifier_set}).")
+        return None
+    
+    max_ver = max(filtered_versions)
+    if image_name_for_debug == "vault":
+        eprint(f"  DEBUG FOR VAULT: max(filtered_versions) determined as: {max_ver}")
+    
+    return str(max_ver)
+
+
+def main():
+    # ... (main function remains largely the same) ...
+    try:
+        with open("image_references.json", 'r') as f:
+            images_data = json.load(f)
+    except FileNotFoundError:
+        eprint("Error: image_references.json not found.")
+        return
+    except json.JSONDecodeError:
+        eprint("Error: Could not decode image_references.json.")
+        return
+
+    try:
+        with open(".github/renovate.json5", 'r') as f:
+            renovate_config = json5.load(f)
+    except FileNotFoundError:
+        eprint("Warning: .github/renovate.json5 not found. Proceeding without rules.")
+        renovate_config = {} 
+    except Exception as e:
+        eprint(f"Error parsing .github/renovate.json5: {e}")
+        renovate_config = {}
+
+    package_rules = renovate_config.get("packageRules", [])
+    proposed_updates = []
+    processed_image_names = {} 
+
+    for item in images_data:
+        file_path = item["file_path"]
+        image_name = item["image_name"]
+        current_version_str = str(item["image_tag"]) 
+
+        eprint(f"\nProcessing: {image_name}:{current_version_str} (from {file_path})")
+
+        if current_version_str.lower().startswith("sha256:"):
+            eprint(f"  Skipping update check: Current version is a digest: {current_version_str}")
+            proposed_updates.append({
+                "filePath": file_path, "imageName": image_name, "currentVersion": current_version_str,
+                "newVersion": current_version_str, "updateNeeded": False,
+                "reason": "Current version is a digest."
+            })
+            continue
+        
+        current_semver = None
+        try:
+            parsed_tag = current_version_str[1:] if current_version_str.startswith('v') else current_version_str
+            current_semver = parse_version(parsed_tag)
+        except InvalidVersion:
+            eprint(f"  Current version '{current_version_str}' for {image_name} is not a standard semantic version.")
+
+        applicable_rule = None
+        for rule in package_rules:
+            if "matchPackagePatterns" in rule:
+                for pattern_str in rule["matchPackagePatterns"]:
+                    try:
+                        if re.search(pattern_str, image_name):
+                            applicable_rule = rule
+                            eprint(f"  Found matching Renovate rule for {image_name} with pattern '{pattern_str}'")
+                            break
+                    except re.error as e:
+                        eprint(f"  Regex error for pattern '{pattern_str}': {e}")
+            if applicable_rule:
+                break
+        
+        specifier_set = None
+        rule_reason_parts = ["No specific rule found."]
+        if applicable_rule:
+            rule_reason_parts = [f"Rule pattern '{applicable_rule.get('matchPackagePatterns')}' matched."]
+            if "allowedVersions" in applicable_rule:
+                specifier_set = parse_allowed_versions(applicable_rule["allowedVersions"])
+                if specifier_set:
+                    rule_reason_parts.append(f"Allowed versions: '{applicable_rule['allowedVersions']}' (parsed as '{specifier_set}').")
+                    eprint(f"  Applied rule for {image_name}: allowedVersions='{applicable_rule['allowedVersions']}' parsed as '{specifier_set}'")
+                else:
+                    rule_reason_parts.append(f"Failed to parse allowedVersions for {image_name}: '{applicable_rule['allowedVersions']}'.")
+                    eprint(f"  Rule found for {image_name} but failed to parse allowedVersions: '{applicable_rule['allowedVersions']}'")
+        
+        tags = None
+        effective_image_name_for_crane = image_name 
+        if image_name in processed_image_names:
+            tags, effective_image_name_for_crane = processed_image_names[image_name]
+            eprint(f"  Using cached tags for {image_name} (effective name for crane: {effective_image_name_for_crane})")
+        else:
+            tags, effective_image_name_for_crane = get_tags_from_registry(image_name)
+            processed_image_names[image_name] = (tags, effective_image_name_for_crane)
+
+        if tags is None:
+            eprint(f"  Could not fetch tags for {effective_image_name_for_crane}. Skipping version check.")
+            proposed_updates.append({
+                "filePath": file_path, "imageName": image_name, "currentVersion": current_version_str,
+                "newVersion": "Error: Could not fetch tags", "updateNeeded": False,
+                "reason": f"Failed to fetch tags for {effective_image_name_for_crane}."
+            })
+            continue
+
+        latest_allowed_version_str = get_latest_matching_version(tags, image_name, specifier_set, current_version_str)
+
+        update_needed = False
+        new_version_display = current_version_str
+        
+        if latest_allowed_version_str:
+            eprint(f"  For {image_name}: Current version for comparison: {current_semver if current_semver else current_version_str}, Latest matching version from registry: {latest_allowed_version_str}")
+            latest_semver = None
+            try:
+                parsed_latest_tag = latest_allowed_version_str[1:] if latest_allowed_version_str.startswith('v') else latest_allowed_version_str
+                latest_semver = parse_version(parsed_latest_tag)
+            except InvalidVersion:
+                 eprint(f"  Error: latest_allowed_version_str '{latest_allowed_version_str}' for {image_name} from registry is not valid semver. This should not happen.")
+
+            if latest_semver:
+                if current_semver: 
+                    if latest_semver > current_semver:
+                        update_needed = True
+                        new_version_display = latest_allowed_version_str 
+                        rule_reason_parts.append(f"Latest satisfying version is {latest_allowed_version_str}.")
+                    elif latest_semver == current_semver and latest_allowed_version_str != current_version_str and latest_allowed_version_str != ('v' + current_version_str) and ('v'+latest_allowed_version_str) != current_version_str :
+                        update_needed = True 
+                        new_version_display = latest_allowed_version_str
+                        rule_reason_parts.append(f"Proposing canonical version {latest_allowed_version_str} (current: {current_version_str}).")
+                    else: 
+                        new_version_display = current_version_str 
+                        rule_reason_parts.append(f"Already at or above the latest satisfying version ({latest_allowed_version_str}).")
+                else: 
+                    if latest_allowed_version_str != current_version_str:
+                        update_needed = True
+                        new_version_display = latest_allowed_version_str
+                        rule_reason_parts.append(f"Latest satisfying version is {latest_allowed_version_str} (current is non-standard: {current_version_str}).")
+                    else:
+                         rule_reason_parts.append(f"Already at version {current_version_str} (non-standard).")
+        
+        if not latest_allowed_version_str: 
+            eprint(f"  No suitable version found for {image_name} matching spec: {specifier_set if specifier_set else 'any stable/compatible'}.")
+            rule_reason_parts.append("No suitable version found in registry matching constraints.")
+            if specifier_set and current_semver and not specifier_set.contains(current_semver):
+                rule_reason_parts.append(f"Current version {current_version_str} VIOLATES rule '{specifier_set}'. No alternative found.")
+
+        final_reason = " ".join(rule_reason_parts)
+        if len(rule_reason_parts) > 1 and rule_reason_parts[0] == "No specific rule found.":
+            final_reason = " ".join(rule_reason_parts[1:])
+
+        proposed_updates.append({
+            "filePath": file_path, "imageName": image_name, "currentVersion": current_version_str,
+            "newVersion": new_version_display, "updateNeeded": update_needed,
+            "reason": final_reason.strip()
+        })
+
+    try:
+        with open("image_updates_proposed.json", 'w') as f:
+            json.dump(proposed_updates, f, indent=2)
+        eprint("\nSuccessfully wrote image_updates_proposed.json")
+    except IOError:
+        eprint("Error: Could not write image_updates_proposed.json.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit updates several container images to their latest versions, respecting pinning rules defined in .github/renovate.json5.

Updated images include:
- lscr.io/linuxserver/bambustudio to 2.0.3
- postgres to 16.9
- redis to 7.4.3
- ghcr.io/advplyr/audiobookshelf to 2.23.0
- ghcr.io/home-operations/lidarr to 2.12.0.4633
- ghcr.io/home-operations/prowlarr to 1.36.2.5059
- ghcr.io/home-operations/radarr to 5.23.3.9987
- ghcr.io/home-operations/readarr to 0.4.16.2793
- ghcr.io/home-operations/sabnzbd to 4.5.1

Notes:
- I encountered an issue fetching the latest tags for 'vault'; it may not be at the absolute latest version.
- I encountered an error fetching tags for 'lscr.io/linuxserver/manyfoldstudio'; it was not updated.